### PR TITLE
Make jaraco.apt & yg.lockfile imports optional

### DIFF
--- a/jaraco/context.py
+++ b/jaraco/context.py
@@ -13,8 +13,15 @@ try:
 except Exception:
     import contextlib as contextlib2
 
-import jaraco.apt
-import yg.lockfile
+try:
+    import jaraco.apt as apt
+except ImportError:
+    apt = None
+
+try:
+    import yg.lockfile
+except ImportError:
+    yg = None
 
 
 __metaclass__ = type
@@ -131,6 +138,12 @@ def dependency_context(package_names, aggressively_remove=False):
     """
     installed_packages = []
     log = logging.getLogger(__name__)
+    if apt is None:
+        log.error("jaraco.apt not found installed")
+        raise ImportError("jaraco.apt not found installed")
+    if yg is None:
+        log.error("yg.lockfile not found installed")
+        raise ImportError("yg.lockfile not found installed")
     try:
         if not package_names:
             logging.debug('No packages requested')
@@ -144,7 +157,7 @@ def dependency_context(package_names, aggressively_remove=False):
                 stderr=subprocess.STDOUT,
             )
             log.debug('Aptitude output:\n%s', output)
-            installed_packages = jaraco.apt.parse_new_packages(
+            installed_packages = apt.parse_new_packages(
                 output, include_automatic=aggressively_remove
             )
             if not installed_packages:


### PR DESCRIPTION
Handle missing jaraco.apt & yg.lockfile modules more gracefully,
delaying the error until dependency_context is actually used.  These
two modules are only used by the dependency_context, and this context
can only work on apt-based systems, so there is no point in forcing
the extraneous dependencies on systems that do not use apt where
jaraco.context is being installed for other context managers.