### PR TITLE
Provide native tarfile functionality

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,32 @@
+import http.server
+import io
+import functools
+import tarfile
+import threading
+
+import portend
+import pytest
+
+
+@pytest.fixture
+def tarfile_served(tmp_path_factory):
+    """
+    Start an HTTP server serving a tarfile.
+    """
+    tmp_path = tmp_path_factory.mktemp('www')
+    fn = tmp_path / 'served.tgz'
+    tf = tarfile.open(fn, mode='w:gz')
+    info = tarfile.TarInfo('served/contents.txt')
+    tf.addfile(info, io.BytesIO('hello, contents'.encode()))
+    tf.close()
+    httpd, url = start_server(tmp_path)
+    with httpd:
+        yield url + '/served.tgz'
+
+
+def start_server(path):
+    _host, port = addr = ('', portend.find_available_local_port())
+    Handler = functools.partial(http.server.SimpleHTTPRequestHandler, directory=path)
+    httpd = http.server.HTTPServer(addr, Handler)
+    threading.Thread(target=httpd.serve_forever, daemon=True).start()
+    return httpd, f'http://localhost:{port}'

--- a/jaraco/context.py
+++ b/jaraco/context.py
@@ -51,7 +51,7 @@ def tarball(
     #  then
     #  use -C to cause the files to be extracted to {target_dir}. This ensures
     #  that we always know where the files were extracted.
-    runner('mkdir {target_dir}'.format(**vars()))
+    os.mkdir(target_dir)
     try:
         getter = 'wget {url} -O -'
         extract = 'tar x{compression} --strip-components=1 -C {target_dir}'
@@ -59,7 +59,7 @@ def tarball(
         runner(cmd.format(compression=infer_compression(url), **vars()))
         yield target_dir
     finally:
-        runner('rm -Rf {target_dir}'.format(**vars()))
+        shutil.rmtree(target_dir)
 
 
 def _compose(*cmgrs):

--- a/jaraco/context.py
+++ b/jaraco/context.py
@@ -34,6 +34,15 @@ def tarball(
 ) -> Iterator[str | os.PathLike]:
     """
     Get a tarball, extract it, yield, then clean up.
+
+    >>> import urllib.request
+    >>> url = getfixture('tarfile_served')
+    >>> target = getfixture('tmp_path') / 'out'
+    >>> tb = tarball(url, target_dir=target)
+    >>> import pathlib
+    >>> with tb as extracted:
+    ...     contents = pathlib.Path(extracted, 'contents.txt').read_text()
+    >>> assert not os.path.exists(extracted)
     """
     if target_dir is None:
         target_dir = os.path.basename(url).replace('.tar.gz', '').replace('.tgz', '')

--- a/jaraco/context.py
+++ b/jaraco/context.py
@@ -46,17 +46,16 @@ def tarball(
     """
     if target_dir is None:
         target_dir = os.path.basename(url).replace('.tar.gz', '').replace('.tgz', '')
-    runner = functools.partial(subprocess.check_call, shell=True)
     # In the tar command, use --strip-components=1 to strip the first path and
     #  then
     #  use -C to cause the files to be extracted to {target_dir}. This ensures
     #  that we always know where the files were extracted.
     os.mkdir(target_dir)
     try:
-        getter = 'wget {url} -O -'
-        extract = 'tar x{compression} --strip-components=1 -C {target_dir}'
+        getter = f'wget {url} -O -'
+        extract = f'tar x{infer_compression(url)} --strip-components=1 -C {target_dir}'
         cmd = ' | '.join((getter, extract))
-        runner(cmd.format(compression=infer_compression(url), **vars()))
+        subprocess.check_call(cmd, shell=True)
         yield target_dir
     finally:
         shutil.rmtree(target_dir)

--- a/newsfragments/5.feature.rst
+++ b/newsfragments/5.feature.rst
@@ -1,0 +1,1 @@
+Implemented tarfile using native functionality and avoiding subprocessing, making it portable.

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,6 +28,7 @@ testing =
 	pytest-ruff >= 0.2.1
 
 	# local
+	portend
 
 docs =
 	# upstream

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,6 +16,7 @@ classifiers =
 include_package_data = true
 python_requires = >=3.8
 install_requires =
+	backports.tarfile; python_version < "3.12"
 
 [options.extras_require]
 testing =


### PR DESCRIPTION
Closes #5 

- **Add a test harness and test for tarball**
- **Replace subprocess calls with native ones for mkdir/rmtree. Ref #5**
- **Prefer f-strings and remove partial wrapper.**
- **Request and decompress the tarfile natively**
- **Rely on filter argument to extractall when available.**
- **Load the tarfile into memory to allow seeking for older tarfile implementation.**
- **Rely on backports.tarfile for consistent tarfile behavior and streaming capability.**
