### PR TITLE
Fix condition for skipping safety test on Python 3.12.

### DIFF
--- a/tests/test_safety.py
+++ b/tests/test_safety.py
@@ -33,7 +33,7 @@ cases = [
             expect=does_not_raise(),
         ),
         marks=pytest.mark.skipif(
-            (3, 11) < sys.version_info < (3, 13),
+            (3, 12) <= sys.version_info < (3, 13),
             reason='Fails with FileExistsError on Python 3.12',
         ),
     ),


### PR DESCRIPTION
Condition, introduced in https://github.com/jaraco/jaraco.context/commit/398390e0ac4faf43e6449374964bbe76f0663bc1, allows to skip the safety test in Python 3.11 as well, though surely meant for 3.12 only.
Let me show the difference in REPL output:
```python
Python 3.11.14 (main, Feb  4 2026, 20:23:03) [GCC 14.2.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import sys
>>> sys.version_info
sys.version_info(major=3, minor=11, micro=14, releaselevel='final', serial=0)
>>> (3, 11) < sys.version_info < (3, 13)
True
>>> (3, 12) <= sys.version_info < (3, 13)
False
``` 
```python
Python 3.12.12 (main, Jan 16 2026, 00:00:00) [GCC 14.3.1 20250617 (Red Hat 14.3.1-2)] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import sys
>>> sys.version_info
sys.version_info(major=3, minor=12, micro=12, releaselevel='final', serial=0)
>>> (3, 11) < sys.version_info < (3, 13)
True
>>> (3, 12) <= sys.version_info < (3, 13)
True
``` 
The safety test successfully passes on Python 3.11.